### PR TITLE
Enable cache components: apply use cache to projects page and footer

### DIFF
--- a/app/(pages)/projects/page.tsx
+++ b/app/(pages)/projects/page.tsx
@@ -1,3 +1,4 @@
+'use cache'
 import { createMetadata } from '@/app/utils/metadata'
 import { SchemaFactory } from '@/app/utils/schemaFactory'
 import SchemaInjector from '@/app/components/schema/SchemaInjector'

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -1,8 +1,9 @@
+"use cache"
 import { Icon } from '@iconify/react'
 import { getPageTitle, GITHUB_URL, VERSION } from '@/app/constants/baseData'
 import { LinkWrapper } from '@/app/components/shared/LinkWrapper'
 
-export const Footer = () => (
+export const Footer = async () => (
   <footer>
     <h2>Footer</h2>
     <p>

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   experimental: {
     esmExternals: true,
   },
+  cacheComponents: true,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Add cachComponents directive to next config and apply use cache to projects page and footer.